### PR TITLE
Makefile: Properly utilize B14CKB1RD build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,13 @@ SUBARCH := $(shell uname -m | sed -e s/i.86/x86/ -e s/x86_64/x86/ \
 # Default value for CROSS_COMPILE is not to prefix executables
 # Note: Some architectures assign CROSS_COMPILE in their arch/*/Makefile
 ARCH		?= $(SUBARCH)
-CROSS_COMPILE	?= $(CONFIG_CROSS_COMPILE:"%"=%)
+
+# Check for B14CKB1RD Build System
+ifeq ($(TOOLCHAIN_SUFFIX),)
+  CROSS_COMPILE	?= $(CONFIG_CROSS_COMPILE:"%"=%)
+else
+  CROSS_COMPILE	:= $(TOOLCHAIN_SUFFIX)
+endif
 
 # Architecture as present in compile.h
 UTS_MACHINE 	:= $(ARCH)


### PR DESCRIPTION
If TOOLCHAIN_SUFFIX is set, ignore user input for CROSS_COMPILE.